### PR TITLE
Corregido el error que hacía que la gráfica saliese fuera.

### DIFF
--- a/DS.ui
+++ b/DS.ui
@@ -17,10 +17,10 @@
    <widget class="QWidget" name="mplwindow" native="true">
     <property name="geometry">
      <rect>
-      <x>9</x>
-      <y>9</y>
+      <x>10</x>
+      <y>100</y>
       <width>621</width>
-      <height>531</height>
+      <height>461</height>
      </rect>
     </property>
     <property name="sizePolicy">
@@ -32,7 +32,17 @@
     <property name="layoutDirection">
      <enum>Qt::LeftToRight</enum>
     </property>
-    <layout class="QVBoxLayout" name="mplvl"/>
+    <layout class="QVBoxLayout" name="mplvl">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+    </layout>
    </widget>
    <widget class="QListWidget" name="mplfigs">
     <property name="geometry">
@@ -109,8 +119,8 @@
     <widget class="QLabel" name="label">
      <property name="geometry">
       <rect>
-       <x>0</x>
-       <y>50</y>
+       <x>110</x>
+       <y>10</y>
        <width>71</width>
        <height>16</height>
       </rect>
@@ -170,6 +180,84 @@
     </property>
     <property name="text">
      <string>Back</string>
+    </property>
+   </widget>
+   <widget class="QSlider" name="slider_simulation">
+    <property name="geometry">
+     <rect>
+      <x>30</x>
+      <y>70</y>
+      <width>581</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="orientation">
+     <enum>Qt::Horizontal</enum>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_5">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>40</y>
+      <width>81</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Simulation Time:</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_4">
+    <property name="geometry">
+     <rect>
+      <x>100</x>
+      <y>40</y>
+      <width>46</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="ButtonOn">
+    <property name="geometry">
+     <rect>
+      <x>180</x>
+      <y>20</y>
+      <width>75</width>
+      <height>23</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Go on</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="ButtonBack">
+    <property name="geometry">
+     <rect>
+      <x>280</x>
+      <y>20</y>
+      <width>75</width>
+      <height>23</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Go back</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="ButtonPause">
+    <property name="geometry">
+     <rect>
+      <x>380</x>
+      <y>20</y>
+      <width>75</width>
+      <height>23</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Pause</string>
     </property>
    </widget>
   </widget>
@@ -232,6 +320,22 @@
     <hint type="destinationlabel">
      <x>302</x>
      <y>282</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>slider_simulation</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>label_4</receiver>
+   <slot>setNum(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>110</x>
+     <y>548</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>108</x>
+     <y>529</y>
     </hint>
    </hints>
   </connection>

--- a/Interfaz.py
+++ b/Interfaz.py
@@ -67,13 +67,21 @@ class DS(QMainWindow,Ui_MainWindow):
         self.setupUi(self)
 #        self.mplfigs.hide()
 #        self.mplwindow.hide()
+        self.ButtonOn.hide()
+        self.ButtonBack.hide()
+        self.ButtonPause.hide()
         self.start.clicked.connect(self.start1)
         self.back.clicked.connect(self.close)
+#        self.ButtonOn.clicked.connect(self.on)
+#        self.ButtonBack.clicked.connect(self.back)
+#        self.ButtonPause.clicked.connect(self.pause)        
         self.fig_dict={}
         
         self.mplfigs.itemClicked.connect(self.changefig)
-        
+        self.label_5.hide()
+        self.slider_simulation.hide()
         self.horizontalSlider.valueChanged.connect(self.initial)
+        self.slider_simulation.valueChanged.connect(self.simulation)
         fig=Figure()
         self.addmpl(fig)        
     
@@ -118,10 +126,18 @@ class DS(QMainWindow,Ui_MainWindow):
     def addmpl(self,fig):
         self.canvas=FigureCanvas(fig)
         self.toolbar=NavigationToolbar(self.canvas,self,coordinates=True)
-        self.mplvl.addWidget(self.toolbar)        
         self.mplvl.addWidget(self.canvas)
         self.canvas.draw()
-   
+        self.mplvl.addWidget(self.toolbar)
+
+#    def pause(self):
+#        print "pause"
+#    def on(self):
+#        print "on"
+#    def back(s):
+#        print "back"
+        
+
         
     def start1(self):
         prevdir = os.getcwd()
@@ -131,9 +147,17 @@ class DS(QMainWindow,Ui_MainWindow):
             file.write ('%s\t%s' %(self.horizontalSlider.value(),self.spinBox.value()))
             file.close()
             subprocess.Popen('python gpe_fft_ts_DS_v1.py',shell=True)
-            print os.getcwd()
-            time.sleep(30.0*self.spinBox.value())
-            print "READY"
+            print (os.getcwd())
+            time.sleep(20.0*self.spinBox.value())
+            print ("READY")
+            self.label_5.show()
+            self.ButtonOn.show()
+            self.ButtonBack.show()
+            self.ButtonPause.show()
+            self.slider_simulation.show()
+            self.slider_simulation.setMinimum(0)
+            self.slider_simulation.setMaximum(self.spinBox.value()*88-1)
+            self.slider_simulation.setSingleStep(1)
         
             file = open('energies.txt', 'r')
             lines = file.readlines()
@@ -203,7 +227,38 @@ class DS(QMainWindow,Ui_MainWindow):
         self.addfig('ENERGY',fig2)
         self.addfig('MINUS',fig3)
                 
-        
+    def simulation(self):
+        time=88*self.spinBox.value()
+        value=self.slider_simulation.value()
+        prevdir = os.getcwd()
+        try:
+            os.chdir(os.path.expanduser('./darksolitons'))
+            for i in range(1,time+1):
+                file=open('WfDs-%08d.txt'%(i),'r')
+                globals()['lines%s' %i]=file.readlines()
+                file.close()
+#            
+#            
+                if value==i:                    
+                    x1=[]
+                    x2=[]
+                    for line in (globals()['lines%s' %i]):
+                        p=line.split()
+                        x1.append(float(p[0]))
+                        x2.append(float(p[1]))
+                    xv1=np.array(x1)
+                    xv2=np.array(x2)
+                    
+                    self.rmmpl()
+                    fig=Figure()
+                    axf=fig.add_subplot(111)
+                    axf.plot(xv1,xv2)
+                    axf.set_title('STATE')
+                    self.addmpl(fig)
+        finally:
+            os.chdir(prevdir)
+            
+            
     def rmmpl(self):
         self.mplvl.removeWidget(self.canvas)
         self.canvas.close()


### PR DESCRIPTION
He corregido el error que hacía plotear la gráfica fuera cuando movías rápido el slider. Básicamente he cambiado algunos parámetros de algunos objetos de la interfaz y he reestructurado la posición de estos. Lo que pasaba es que cuando se dibujaba la gráfica en el canvas no se exactamente porque pero la ploteaba un poco fuera y luego la reposicionaba al centro de la ventana, corrigiendo ciertos parámetros he conseguido que no haga esto. Decidme si a vosotros os funciona así. También podréis ver que he añadido 3 botones pero aun no son funcionales, serán los que controlen la simulación. Uno para delante, otro para atrás y un pausa.
